### PR TITLE
Fix space creation by including host_id in request body

### DIFF
--- a/src/app/host/spaces/new/page.tsx
+++ b/src/app/host/spaces/new/page.tsx
@@ -88,6 +88,7 @@ function CreateRoomContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...form,
+          host_id: host.id,
           price_cents: form.price * 100,
         }),
       });


### PR DESCRIPTION
The create space form was not passing the authenticated user's host_id to the API endpoint, causing "Host ID required" error.