### PR TITLE
Fix time formatting across all space-related pages

### DIFF
--- a/src/app/founder/page.tsx
+++ b/src/app/founder/page.tsx
@@ -559,7 +559,7 @@ export default function FounderDashboard() {
                             month: 'short',
                             day: 'numeric',
                           })}{' '}
-                          at {space.time}
+                          at {new Date(`${space.date}T${space.time}`).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
                         </p>
                       </div>
                       <div className="text-right text-sm">

--- a/src/app/host/spaces/[id]/page.tsx
+++ b/src/app/host/spaces/[id]/page.tsx
@@ -309,7 +309,7 @@ function HostSpaceContent() {
                 <Badge variant={statusBadgeVariant} size="md">{space.status}</Badge>
               </div>
               <p className="text-[var(--text-secondary)] text-[var(--text-sm)]">
-                {spaceDate.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })} at {space.time}
+                {spaceDate.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })} at {spaceDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
                 {' · '}{space.location_hint || 'Location set'}
                 {' · '}<span className="capitalize">{tone}</span> vibe
               </p>
@@ -665,7 +665,7 @@ ${new Date(space.date).toLocaleDateString('en-US', {
   weekday: 'short',
   month: 'short',
   day: 'numeric',
-})} at ${space.time} · ${space.location_hint || 'Location TBA'}
+})} at ${spaceDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })} · ${space.location_hint || 'Location TBA'}
 
 This is a space where strangers meet with intention.
 

--- a/src/app/my-spaces/page.tsx
+++ b/src/app/my-spaces/page.tsx
@@ -134,6 +134,13 @@ export default function MyRoomsPage() {
     }
   };
 
+  const formatTime = (timeString: string) => {
+    const [hours, minutes] = timeString.split(':').map(Number);
+    const date = new Date();
+    date.setHours(hours, minutes);
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  };
+
   if (loading || authLoading) {
     return (
       <div className="min-h-screen bg-[var(--bg-base)] flex items-center justify-center">
@@ -406,7 +413,7 @@ export default function MyRoomsPage() {
                           <div className="flex flex-wrap items-center gap-3 text-[var(--text-sm)] text-[var(--text-secondary)]">
                             <span>{formatDate(space.date)}</span>
                             <span className="text-[var(--text-muted)]">at</span>
-                            <span>{space.time}</span>
+                            <span>{formatTime(space.time)}</span>
                             {space.location_hint && (
                               <>
                                 <span className="text-[var(--text-muted)]">in</span>

--- a/src/app/spaces/[id]/page.tsx
+++ b/src/app/spaces/[id]/page.tsx
@@ -482,7 +482,7 @@ export default function PublicRoomPage() {
                 {spaceDate.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
               </div>
               <div className="text-[var(--text-sm)] text-[var(--text-secondary)]">
-                {space.time} - {new Date(spaceDate.getTime() + space.duration_minutes * 60 * 1000).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+                {spaceDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })} - {new Date(spaceDate.getTime() + space.duration_minutes * 60 * 1000).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
               </div>
             </div>
           </div>

--- a/src/components/composed/space-card.tsx
+++ b/src/components/composed/space-card.tsx
@@ -102,7 +102,13 @@ export function SpaceCard({
         <div className="flex items-center gap-2 text-[var(--text-xs)] text-[var(--text-secondary)] mb-2">
           <span>{date}</span>
           <span className="w-1 h-1 rounded-full bg-[var(--text-muted)]" />
-          <span>{time}</span>
+          <span>{(() => {
+            // Format time like "7:00 PM" from "19:00:00" or "19:00"
+            const [hours, minutes] = time.split(':').map(Number);
+            const date = new Date();
+            date.setHours(hours, minutes);
+            return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+          })()}</span>
         </div>
 
         {/* Title */}


### PR DESCRIPTION
Times were displaying raw database format (19:00:00) instead of user-friendly format (7:00 PM). Fixed in:
- SpaceCard component (used by discover, host dashboard, my-spaces)
- Host space detail page (header and settings preview)
- Public space page (event time display)
- Founder dashboard
- My spaces page